### PR TITLE
feat: integrate with determined

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,12 @@ repos:
     hooks:
       - id: black
         language_version: python3.8
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
-    hooks:
-      - id: codespell
-        exclude: >
-          (?x)^(
-              .*\.json|ignore.txt
-          )$
-        args: [--check-filenames, --check-hidden, --ignore-words=ignore.txt]
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: v2.1.0
+  #   hooks:
+  #     - id: codespell
+  #       exclude: >
+  #         (?x)^(
+  #             .*\.json|ignore.txt
+  #         )$
+  #       args: [--check-filenames, --check-hidden, --ignore-words=ignore.txt]

--- a/lm_eval/tasks/hendrycks_test.py
+++ b/lm_eval/tasks/hendrycks_test.py
@@ -14,7 +14,6 @@ Homepage: https://github.com/hendrycks/test
 """
 from lm_eval.base import MultipleChoiceTask
 
-
 _CITATION = """
 @article{hendryckstest2021,
     title={Measuring Massive Multitask Language Understanding},

--- a/main.py
+++ b/main.py
@@ -106,10 +106,6 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
         with open(args.output_path, "w") as f:
             f.write(dumped)
 
-    print(
-        f"{args.model} ({args.model_args}), limit: {args.limit}, provide_description: {args.provide_description}, "
-        f"num_fewshot: {args.num_fewshot}, batch_size: {args.batch_size}"
-    )
     print(evaluator.make_table(results))
 
 

--- a/main.py
+++ b/main.py
@@ -80,7 +80,8 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
     # GG_NOTE: task will always be a single string, but it may be a glob-pattern which will get
     # converted to multiple tests.
     assert isinstance(hparams["task"], str)
-    task_names = pattern_match(hparams["task"], tasks.ALL_TASKS)
+    task_names = pattern_match([hparams["task"]], tasks.ALL_TASKS)
+    assert task_names
 
     results = evaluator.simple_evaluate(
         model=model,

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import determined as det
 
-from lm_eval import evaluator
+from lm_eval import evaluator, tasks, utils
 
 logging.getLogger("openai").setLevel(logging.WARNING)
 
@@ -70,18 +70,17 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
         )
     else:
         model_args = None
-    # We always run a single task
-    if isinstance(hparams["task"], str):
-        task = [hparams["task"]]
-    elif isinstance(hparams["task"], list):
-        task = hparams["task"]
+    # GG_NOTE: task will always be a single string, but it may be a glob-pattern which will get
+    # converted to multiple tests.
+    assert isinstance(hparams["task"], str)
+    task_names = utils.pattern_match(hparams["task"], tasks.ALL_TASKS)
 
     results = evaluator.simple_evaluate(
         model=model,
         core_context=core_context,
         uuid=uuid,
         model_args=model_args,
-        tasks=task,
+        tasks=task_names,
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
         device=args.device,

--- a/main.py
+++ b/main.py
@@ -47,14 +47,6 @@ def parse_args():
 # match at least one of the patterns
 
 
-def pattern_match(patterns, source_list):
-    task_names = set()
-    for pattern in patterns:
-        for matching in fnmatch.filter(source_list, pattern):
-            task_names.add(matching)
-    return list(task_names)
-
-
 def main(core_context: det.core.Context, hparams: Dict[str, Any]):
     args = parse_args()
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 import argparse
+import fnmatch
 import json
 import logging
-import fnmatch
+from typing import Any, Dict
 
-from lm_eval import tasks, evaluator
+import determined as det
+
+from lm_eval import evaluator
 
 logging.getLogger("openai").setLevel(logging.WARNING)
 
@@ -27,9 +30,7 @@ class MultiChoice:
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", required=True)
     parser.add_argument("--model_args", default="")
-    parser.add_argument("--tasks", default=None, choices=MultiChoice(tasks.ALL_TASKS))
     parser.add_argument("--provide_description", action="store_true")
     parser.add_argument("--num_fewshot", type=int, default=0)
     parser.add_argument("--batch_size", type=int, default=None)
@@ -37,15 +38,15 @@ def parse_args():
     parser.add_argument("--output_path", default=None)
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--no_cache", action="store_true")
-    parser.add_argument("--decontamination_ngrams_path", default=None)
     parser.add_argument("--description_dict_path", default=None)
     parser.add_argument("--check_integrity", action="store_true")
-
     return parser.parse_args()
 
 
 # Returns a list containing all values of the source_list that
 # match at least one of the patterns
+
+
 def pattern_match(patterns, source_list):
     task_names = set()
     for pattern in patterns:
@@ -54,7 +55,7 @@ def pattern_match(patterns, source_list):
     return list(task_names)
 
 
-def main():
+def main(core_context: det.core.Context, hparams: Dict[str, Any]):
     args = parse_args()
 
     assert not args.provide_description  # not implemented
@@ -64,31 +65,40 @@ def main():
             "WARNING: --limit SHOULD ONLY BE USED FOR TESTING. REAL METRICS SHOULD NOT BE COMPUTED USING LIMIT."
         )
 
-    if args.tasks is None:
-        task_names = tasks.ALL_TASKS
-    else:
-        task_names = pattern_match(args.tasks.split(","), tasks.ALL_TASKS)
-
-    print(f"Selected Tasks: {task_names}")
-
     description_dict = {}
     if args.description_dict_path:
         with open(args.description_dict_path, "r") as f:
             description_dict = json.load(f)
 
+    model = "hf"
+    uuid = hparams["model_args"]["uuid"]
+    if uuid is None:
+        model_args = (
+            f'pretrained={hparams["model_args"]["pretrained_model_name_or_path"]}'
+        )
+    else:
+        model_args = None
+    # We always run a single task
+    if isinstance(hparams["task"], str):
+        task = [hparams["task"]]
+    elif isinstance(hparams["task"], list):
+        task = hparams["task"]
+
     results = evaluator.simple_evaluate(
-        model=args.model,
-        model_args=args.model_args,
-        tasks=task_names,
+        model=model,
+        core_context=core_context,
+        uuid=uuid,
+        model_args=model_args,
+        tasks=task,
         num_fewshot=args.num_fewshot,
         batch_size=args.batch_size,
         device=args.device,
         no_cache=args.no_cache,
         limit=args.limit,
         description_dict=description_dict,
-        decontamination_ngrams_path=args.decontamination_ngrams_path,
         check_integrity=args.check_integrity,
     )
+    core_context.train.report_validation_metrics(steps_completed=0, metrics=results)
 
     dumped = json.dumps(results, indent=2)
     print(dumped)
@@ -105,4 +115,13 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    info = det.get_cluster_info()
+    assert info
+    hparams = info.trial.hparams
+    logging.basicConfig(level=logging.INFO, format=det.LOG_FORMAT)
+    try:
+        distributed = det.core.DistributedContext.from_torch_distributed()
+    except KeyError:
+        distributed = None
+    with det.core.init(distributed=distributed) as core_context:
+        main(core_context, hparams)

--- a/main.py
+++ b/main.py
@@ -81,6 +81,8 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
     # converted to multiple tests.
     assert isinstance(hparams["task"], str)
     task_names = pattern_match([hparams["task"]], tasks.ALL_TASKS)
+    print(hparams["task"])
+    print(task_names)
     assert task_names
 
     results = evaluator.simple_evaluate(

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 import determined as det
 
-from lm_eval import evaluator, tasks, utils
+from lm_eval import evaluator, tasks
 
 logging.getLogger("openai").setLevel(logging.WARNING)
 
@@ -45,6 +45,12 @@ def parse_args():
 
 # Returns a list containing all values of the source_list that
 # match at least one of the patterns
+def pattern_match(patterns, source_list):
+    task_names = set()
+    for pattern in patterns:
+        for matching in fnmatch.filter(source_list, pattern):
+            task_names.add(matching)
+    return list(task_names)
 
 
 def main(core_context: det.core.Context, hparams: Dict[str, Any]):
@@ -70,10 +76,11 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
         )
     else:
         model_args = None
+
     # GG_NOTE: task will always be a single string, but it may be a glob-pattern which will get
     # converted to multiple tests.
     assert isinstance(hparams["task"], str)
-    task_names = utils.pattern_match(hparams["task"], tasks.ALL_TASKS)
+    task_names = pattern_match(hparams["task"], tasks.ALL_TASKS)
 
     results = evaluator.simple_evaluate(
         model=model,

--- a/main.py
+++ b/main.py
@@ -81,8 +81,6 @@ def main(core_context: det.core.Context, hparams: Dict[str, Any]):
     # converted to multiple tests.
     assert isinstance(hparams["task"], str)
     task_names = pattern_match([hparams["task"]], tasks.ALL_TASKS)
-    print(hparams["task"])
-    print(task_names)
     assert task_names
 
     results = evaluator.simple_evaluate(

--- a/tests/test_det.py
+++ b/tests/test_det.py
@@ -8,7 +8,7 @@ from main import pattern_match
 
 
 def test_pattern_match_single():
-    task_names = pattern_match(["qnli"], tasks.ALL_TASKS)
+    task_names = pattern_match(["arc_easy"], tasks.ALL_TASKS)
     assert task_names
     assert len(task_names) == 1
 

--- a/tests/test_det.py
+++ b/tests/test_det.py
@@ -1,0 +1,19 @@
+"""
+Tests for Determined-specific changes which were made.
+"""
+
+
+from lm_eval import tasks
+from main import pattern_match
+
+
+def test_pattern_match_single():
+    task_names = pattern_match(["qnli"], tasks.ALL_TASKS)
+    assert task_names
+    assert len(task_names) == 1
+
+
+def test_pattern_match_glob_two():
+    task_names = pattern_match(["arc_*"], tasks.ALL_TASKS)
+    assert task_names
+    assert len(task_names) == 2

--- a/tests/test_det.py
+++ b/tests/test_det.py
@@ -13,7 +13,7 @@ def test_pattern_match_single():
     assert len(task_names) == 1
 
 
-def test_pattern_match_glob_two():
-    task_names = pattern_match(["arc_*"], tasks.ALL_TASKS)
+def test_pattern_match_glob():
+    task_names = pattern_match(["hendrycksTest-*"], tasks.ALL_TASKS)
     assert task_names
-    assert len(task_names) == 2
+    assert len(task_names) == 57


### PR DESCRIPTION
Initial PR integrating v0.3.0 of the `lm-evaluation-harness` with Determined.

Rough outline of the flow/various components:
1.  A model hub `Model` is paired with a `EvaluationConfig` which contains one or more `tasks`.  
2. Each task is run separately as part of a `grid` search to parallelize the work, and is passed into `main.py` via `hparams[task]`, a single string (the string may be a glob pattern, as in `truthfulqa_*`, which results in running both the `truthfulqa_mc` and `truthfulqa_gen` tasks). Might consider expanding the globs before forming the multi-Trial experiment in the future; right now the glob patterns are submitted.
3. The results from each trial are reported back to the master as validation metrics.  
4. The `ExperimentClient.get_experiment_metrics` method gather up the results from all such trials and returns them as a `dict`. 